### PR TITLE
show forms in rest

### DIFF
--- a/inc/class-register-post-types.php
+++ b/inc/class-register-post-types.php
@@ -28,7 +28,7 @@ class Register_Post_Types {
 			'show_ui'            => true,
 			'has_archive'        => true,
 			'show_in_menu'       => true,
-			'show_in_rest'       => false,
+			'show_in_rest'       => true,
 			'hierarchical'       => false,
 			'menu_icon'          => 'dashicons-list-view',
 			'rewrite'            => [ 'slug' => 'mf_form' ],


### PR DESCRIPTION
It's required to use that post type in Gutenberg block editor